### PR TITLE
[Fix] plugins 중복 선언 수정

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,9 +7,9 @@ import svgr from "vite-plugin-svgr";
 
 // https://vite.dev/config/
 export default defineConfig({
-	plugins: [react(), tailwindcss()],
 	plugins: [
 		react(),
+		tailwindcss(),
 		svgr({
 			svgrOptions: {
 				icon: true,


### PR DESCRIPTION
## 📌 Related Issues

- close #34 

## 📄 Tasks
- `vite.config.ts` 내 중복된 `plugins` 필드 제거
- `react()`, `tailwindcss()`, `svgr()`를 하나의 `plugins` 배열로 병합


## ⭐ PR Point (To Reviewer)
- 기존에 plugins 키가 두 번 선언되어 있어서 에러가 났었는데 수정했습니다 !!!

## 📷 Screenshot

<!-- 작업 결과물에 관련된 사진이나 영상 등을 첨부해주세요 -->

## 🔔 ETC

<!-- 기타 이외 작업 작성 (ex. 참고한 아티클 링크 / 새롭게 알게 된 점 등) -->
