### PR TITLE
[Fix] vercel 404 에러 해결

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+	"rewrites": [
+		{
+			"source": "/(.*)",
+			"destination": "/index.html"
+		}
+	]
+}


### PR DESCRIPTION
## 📌 Related Issues

<!--관련 이슈 언급 -->

- close #139

## 📄 Tasks
- vercel.json 설정

## ⭐ PR Point (To Reviewer)
- SPA에서는 /은 정상 작동하지만 /search는 404가 발생합니다.
- Vercel은 실제 파일 경로를 찾는데 /search 경로에 실제 파일이 없으면 404 에러가 발생한다고 합니다!
- 그래서 모든 경로를 index.html로 리다이렉트하는 설정을 추가했습니다!

## 📷 Screenshot
<img width="1384" height="727" alt="스크린샷 2025-11-27 오후 4 53 58" src="https://github.com/user-attachments/assets/b6d4ee7b-10d6-42a9-9dc6-d56f2d8d91d7" />

<!-- 작업 결과물에 관련된 사진이나 영상 등을 첨부해주세요 -->

## 🔔 ETC

<!-- 기타 이외 작업 작성 (ex. 참고한 아티클 링크 / 새롭게 알게 된 점 등) -->
