### PR TITLE
[Perf] 캐시 최적화

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,7 +14,8 @@ const queryClient = new QueryClient({
 		queries: {
 			staleTime: 1000 * 60 * 5,
 			gcTime: 1000 * 60 * 30,
-			retry: 1,
+			retry: 2,
+			retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 10000),
 			refetchOnWindowFocus: false,
 			refetchOnReconnect: true,
 		},

--- a/vercel.json
+++ b/vercel.json
@@ -4,5 +4,44 @@
 			"source": "/(.*)",
 			"destination": "/index.html"
 		}
+	],
+  
+	"headers": [
+		{
+			"source": "/assets/(.*)",
+			"headers": [
+				{
+					"key": "Cache-Control",
+					"value": "public, max-age=31536000, immutable"
+				}
+			]
+		},
+		{
+			"source": "/(.*).webp",
+			"headers": [
+				{
+					"key": "Cache-Control",
+					"value": "public, max-age=31536000, immutable"
+				}
+			]
+		},
+		{
+			"source": "/(.*).svg",
+			"headers": [
+				{
+					"key": "Cache-Control",
+					"value": "public, max-age=31536000, immutable"
+				}
+			]
+		},
+		{
+			"source": "/index.html",
+			"headers": [
+				{
+					"key": "Cache-Control",
+					"value": "public, max-age=0, must-revalidate"
+				}
+			]
+		}
 	]
 }


### PR DESCRIPTION
## 📌 Related Issues

<!--관련 이슈 언급 -->

- close #106 

## 📄 Tasks

<!-- 작업한 내용을 작성해주세요 -->
- App.tsx에 retry와 retryDelay를 추가했어요
> - retry: 재시도 횟수를 2번으로 늘려서, 문제가 발생했을 때 재시도하며 대응할 수 있어요
> - retryDelay: 지수 백오프 방식으로, 1초부터 시작해서 지수적(1초 → 2초 → 4초 → 최대 10초)으로 증가해서 서버 부담을 줄이고 retry를 안정적으로 할 수 있게 하는 속성이예요!

- vercel.json에 HTTP 캐시 헤더를 설정했어요
> Vercel 배포 환경에서 브라우저 캐시 정책을 설정했어요!
> asset 폴더의 모든 파일은 immutable(절대 변동되지 않음)을 가정하고 31536000초(1년)동안 캐시하게 설정했어요. 이 설정 때문에 재방문시 나머지는 캐시 데이터를 사용해서 다운로드가 없어 성능이 최적화됩니다!

## ⭐ PR Point (To Reviewer)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  -->
위에도 써두었듯, 캐시 최적화는 재방문인 경우에만 효과가 있어요. 그렇기 때문에 당장의 유의미한 성과는 없고, 장기적인 성능 개선을 목표로 합니다! Lighthouse 점수도 변화가 없어서 따로 사진은 첨부하지 않겠습니다 😅

## 📷 Screenshot

<!-- 작업 결과물에 관련된 사진이나 영상 등을 첨부해주세요 -->
<img width="300" height="200" alt="image" src="https://github.com/user-attachments/assets/02088f13-3b41-4c84-92e8-be121bce40db" />

다들 수고하셨어요 💝

## 🔔 ETC

<!-- 기타 이외 작업 작성 (ex. 참고한 아티클 링크 / 새롭게 알게 된 점 등) -->
.