### PR TITLE
[FIX] 쿼리 값 한영 에러 해결

### DIFF
--- a/src/apis/api.ts
+++ b/src/apis/api.ts
@@ -6,7 +6,6 @@ import type { GetPostsRealTimeResponse } from "@/types/getPostsRealtimeResponse"
 import type { GetPostsResponse } from "@/types/getPostsResponse";
 import type { GetPostsSearchResponse } from "@/types/getPostsSearchResponse";
 import type { GetReviewsResponse } from "@/types/getReviewsResponse";
-import { categoryKorToEng } from "@/utils/categoryChanger";
 
 const getPostsHot = () => {
 	return get<GetPostsHotResponse>(END_URL.GET_POSTS_HOT);
@@ -17,9 +16,8 @@ const getReviews = () => {
 };
 
 const getPostsSearch = (keyword: string, category: string, page: number) => {
-	const categoryCode = categoryKorToEng(category);
 	return get<GetPostsSearchResponse>(
-		`${END_URL.GET_POSTS_SEARCH}?category=${categoryCode}&keyword=${encodeURIComponent(keyword)}&page=${page}`,
+		`${END_URL.GET_POSTS_SEARCH}?category=${category}&keyword=${encodeURIComponent(keyword)}&page=${page}`,
 	);
 };
 

--- a/src/components/SearchPage/SearchContainer.tsx
+++ b/src/components/SearchPage/SearchContainer.tsx
@@ -35,7 +35,7 @@ const SearchContainer = () => {
 		(page: number = 1) => {
 			const engCategory = categoryKorToEng(category);
 			// applied- 값들 업데이트 -> API 재호출
-			setAppliedCategory(category);
+			setAppliedCategory(engCategory);
 			setAppliedKeyword(keyword.trim());
 			setAppliedPage(page);
 

--- a/src/components/SearchPage/SearchContainer.tsx
+++ b/src/components/SearchPage/SearchContainer.tsx
@@ -8,6 +8,7 @@ import { Pagination } from "@/components/SearchPage/Pagination";
 import { SearchResultHeader } from "@/components/SearchPage/SearchResultHeader";
 import { SearchResultList } from "@/components/SearchPage/SearchResultList/SearchResultList";
 import { SearchResultListItemSkeleton } from "@/components/SearchPage/SearchResultList/SearchResultListItemSkeleton";
+import type { CategoryCode } from "@/constants/category";
 import { useSearchForm } from "@/hooks/useSearchForm";
 import type { PostsSearchDataType } from "@/types/getPostsSearchResponse";
 import { categoryKorToEng } from "@/utils/categoryChanger";
@@ -24,7 +25,7 @@ const SearchContainer = () => {
 	const { category, keyword, onCategoryChange, onKeywordChange } = useSearchForm(initialCategory, initialKeyword);
 
 	// 실제로 검색에 사용하는 값
-	const [appliedCategory, setAppliedCategory] = useState(initialCategory);
+	const [appliedCategory, setAppliedCategory] = useState<CategoryCode>(initialCategory as CategoryCode);
 	const [appliedKeyword, setAppliedKeyword] = useState(initialKeyword);
 	const [appliedPage, setAppliedPage] = useState(initialPage);
 

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -4,11 +4,11 @@ import AdImg1x from "@/assets/images/img_ad1-1x.webp";
 import AdImg2x from "@/assets/images/img_ad1-2x.webp";
 import AdImg3x from "@/assets/images/img_ad1-3x.webp";
 import { DelayedSuspense } from "@/components/common/DelayedSuspense";
+import { SearchTextField } from "@/components/common/SearchTextField";
 import { BoardContainer } from "@/components/MainPage/BoardConatiner/BoardContainer";
 import { BoardContainerSkeleton } from "@/components/MainPage/BoardConatiner/BoardContainerSkeleton";
 import { Book } from "@/components/MainPage/Book/Book";
 import { BookSkeleton } from "@/components/MainPage/Book/BookSkeleton";
-import { SearchTextField } from "@/components/common/SearchTextField";
 import { useSearchForm } from "@/hooks/useSearchForm";
 
 const MainPage = () => {


### PR DESCRIPTION
## 📌 Related Issues

<!--관련 이슈 언급 -->

- close #163 
- related #161 

## 📄 Tasks

<!-- 작업한 내용을 작성해주세요 -->
검색 api 쿼리키에서 category가 한/영이 혼용되어 들어가는 문제가 있었습니다. 한/영 변경 함수가 적용되는 위치의 문제였고 수정하여 해결했습니다~

### 🔴 문제 원인
기존에는 실제 쿼리키로 사용되는 `appliedCategory`가 한글로 저장되고, api 메소드 쪽에서 영어로 변환하여 검색하는 구조로 이루어져 있었어요.
```tsx
const getPostsSearch = (keyword: string, category: string, page: number) => {
	const categoryCode = categoryKorToEng(category); // 한영 변환
	return get<GetPostsSearchResponse>(
		`${END_URL.GET_POSTS_SEARCH}?category=${categoryCode}&keyword=${encodeURIComponent(keyword)}&page=${page}`,
	);
};
```
그러나 이렇게 하게 되면 `appliedCategory`는 한글로 저장되기 때문에, 검색 시에는 한글 키로 저장되고 새로고침을 하면 searchParams로 key를 가져와서 위와 같은 문제가 발생했던 것이었습니다 !! 🥲

(그래서 단순히 `setAppliedCategory(engCategory)`를 해주었더니, api 함수에서 반환이 안 되어 ALL을 리턴해주어 검색이 안 되는 문제가 발생했던 거였어요 ... 🫠🫠🫠 (#161 이슈 참고))

### 🟢 해결
`appliedCategory`를 영어로 저장하고, 불필요한 api메소드의 한영 변환 함수를 제거하여 문제를 해결했습니다. 😙 추가적으로 `appliedCategory`에 CategoryCode 타입('ALL' | 'INFO' | 'FREE' ...)을 지정하여 타입 범위를 좁혀서 유지보수성을 개선했습니다.

`const [appliedCategory, setAppliedCategory] = useState<CategoryCode>(initialCategory as CategoryCode);`

## ⭐ PR Point (To Reviewer)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  -->
검색 잘 작동 되는지 확인 한 번씩만 부탁드려요 !! 


## 📷 Screenshot

<!-- 작업 결과물에 관련된 사진이나 영상 등을 첨부해주세요 -->

<img width="184" height="65" alt="image" src="https://github.com/user-attachments/assets/fd6e74c5-7d3f-445b-b994-4e202d859360" />

해결 전: 처음 검색 시, '자유게시판'으로 들어가고 새로고침 시 searchParams에서 값을 가져오기 때문에 'FREE'로 변경되어 캐싱이 다시 이루어짐.
<br>

<img width="204" height="167" alt="image" src="https://github.com/user-attachments/assets/8dae3f01-fad6-4cb4-aa74-27df8dea9a63" />

해결 후: 정상적으로 영어 형태로 쿼리키가 저장됨. 

## 🔔 ETC

<!-- 기타 이외 작업 작성 (ex. 참고한 아티클 링크 / 새롭게 알게 된 점 등) -->
